### PR TITLE
Fix unit test

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,3 +1,0 @@
-version: "1"
-domain: ibm.com
-repo: github.com/open-cluster-management/iam-security-policy-controller

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -153,7 +153,7 @@ func main() {
 	// Initialize some variables
 	var generatedClient kubernetes.Interface = kubernetes.NewForConfigOrDie(mgr.GetConfig())
 	common.Initialize(&generatedClient, cfg)
-	policyStatusHandler.Initialize(&generatedClient, mgr, clusterName, namespace, eventOnParent)/* #nosec G104 */
+	policyStatusHandler.Initialize(&generatedClient, mgr, clusterName, namespace, eventOnParent) /* #nosec G104 */
 	// PeriodicallyExecIamPolicies is the go-routine that periodically checks the policies and does the needed work to make sure the desired state is achieved
 	go policyStatusHandler.PeriodicallyExecIamPolicies(frequency)
 

--- a/go.sum
+++ b/go.sum
@@ -1214,7 +1214,6 @@ sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9u
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
-sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
 sigs.k8s.io/structured-merge-diff v1.0.2/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/pkg/apis/policy/v1/deepcopy_test.go
+++ b/pkg/apis/policy/v1/deepcopy_test.go
@@ -23,9 +23,9 @@ var iamPolicy = IamPolicy{
 	}}
 
 var iamPolicySpec = IamPolicySpec{
-	Severity:                        "high",
-	RemediationAction:               "enforce",
-	MaxClusterRoleBindingUsers:     1,
+	Severity:                   "high",
+	RemediationAction:          "enforce",
+	MaxClusterRoleBindingUsers: 1,
 }
 
 var typeMeta = metav1.TypeMeta{

--- a/pkg/apis/policy/v1/doc.go
+++ b/pkg/apis/policy/v1/doc.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 // Package v1 contains API Schema definitions for the policy v1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/open-cluster-management/iam-policy-controller/pkg/apis/policy

--- a/pkg/apis/policy/v1/register.go
+++ b/pkg/apis/policy/v1/register.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 // NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1 contains API Schema definitions for the policy v1 API group

--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package common
 
 import (

--- a/pkg/common/namespace_selection_test.go
+++ b/pkg/common/namespace_selection_test.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package common
 
 import (

--- a/pkg/common/pattern_util.go
+++ b/pkg/common/pattern_util.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package common
 
 import (

--- a/pkg/common/synced_map_utils.go
+++ b/pkg/common/synced_map_utils.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package common
 
 import (

--- a/pkg/common/synced_map_utils_test.go
+++ b/pkg/common/synced_map_utils_test.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 // Package admissionpolicy handles admissionpolicy controller logic
 package common
 

--- a/pkg/controller/iampolicy/iampolicy_controller.go
+++ b/pkg/controller/iampolicy/iampolicy_controller.go
@@ -282,7 +282,7 @@ func checkAllClusterLevel(clusterRoleBindingList *v1.ClusterRoleBindingList) (us
 func convertMaptoPolicyNameKey() map[string]*policiesv1.IamPolicy {
 	plcMap := make(map[string]*policiesv1.IamPolicy)
 	for _, policy := range availablePolicies.PolicyMap {
-		plcMap[fmt.Sprint("%s.%s", policy.Namespace, policy.Name)] = policy
+		plcMap[fmt.Sprintf("%s.%s", policy.Namespace, policy.Name)] = policy
 	}
 	return plcMap
 }

--- a/pkg/controller/iampolicy/iampolicy_controller_test.go
+++ b/pkg/controller/iampolicy/iampolicy_controller_test.go
@@ -232,9 +232,13 @@ func TestHandleAddingPolicy(t *testing.T) {
 	simpleClient.CoreV1().Namespaces().Create(&ns)
 	common.Initialize(&simpleClient, nil)
 	handleAddingPolicy(&iamPolicy)
-	assert.NotNil(t, availablePolicies.PolicyMap["cluster"])
-	handleRemovingPolicy("foo")
-	assert.Nil(t, availablePolicies.PolicyMap["cluster"])
+	policy, found := availablePolicies.GetObject(iamPolicy.Namespace + "." + iamPolicy.Name)
+	assert.True(t, found)
+	assert.NotNil(t, policy)
+	handleRemovingPolicy("foo", "default")
+	policy, found = availablePolicies.GetObject(iamPolicy.Namespace + "." + iamPolicy.Name)
+	assert.False(t, found)
+	assert.Nil(t, policy)
 }
 
 func TestGetContainerID(t *testing.T) {

--- a/pkg/controller/iampolicy/iampolicy_utils.go
+++ b/pkg/controller/iampolicy/iampolicy_utils.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package iampolicy
 
 import (

--- a/pkg/controller/iampolicy/iampolicy_utils_test.go
+++ b/pkg/controller/iampolicy/iampolicy_utils_test.go
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package iampolicy
 
 import (

--- a/tools.go
+++ b/tools.go
@@ -3,10 +3,10 @@
 // Note to U.S. Government Users Restricted Rights:
 // Use, duplication or disclosure restricted by GSA ADP Schedule
 // Contract with IBM Corp.
-// +build tools
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
+// +build tools
 
 // Place any runtime dependencies as imports in this file.
 // Go modules will be forced to download and install them.


### PR DESCRIPTION
Apparently the ` pkg/controller/iampolicy/iampolicy_controller_test.go` unit test has been broken for at least 5 months, so this should fix it: https://github.com/open-cluster-management/iam-policy-controller/pull/48/files#diff-f7ad429aeae782aa8e2d930112ba3725fa73c8f96e651e6c80432f72533e25ad

There was also an `Sprint` statement that looks like it should have been `Sprintf`: https://github.com/open-cluster-management/iam-policy-controller/pull/48/files#diff-9500ee3b4f79063c53b0b9b6131b3b0c528b586814cae12b3cd876d0c6f6ab56

I do have one question: This controller is unique in that it takes a namespace for the `handleRemovingPolicy` function. Is that intentional? It probably doesn't matter since I think it's been working... https://github.com/open-cluster-management/iam-policy-controller/blob/758b0e32aa718fac688a43ee028605e67e898b43/pkg/controller/iampolicy/iampolicy_controller.go#L382-L388