### PR TITLE
Account for OpenShift groups when counting the users with a role

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -132,9 +133,10 @@ func main() {
 
 	// Initialize some variables
 	var generatedClient kubernetes.Interface = kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	var dynamicClient dynamic.Interface = dynamic.NewForConfigOrDie(mgr.GetConfig())
 	common.Initialize(&generatedClient, cfg)
 
-	policyStatusHandler.Initialize(&generatedClient, mgr, clusterName, namespace, eventOnParent) /* #nosec G104 */
+	policyStatusHandler.Initialize(&generatedClient, &dynamicClient, mgr, clusterName, namespace, eventOnParent) /* #nosec G104 */
 	// PeriodicallyExecIamPolicies is the go-routine that periodically checks the policies and does the needed work to make sure the desired state is achieved
 	go policyStatusHandler.PeriodicallyExecIamPolicies(frequency)
 

--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -45,3 +45,9 @@ rules:
   - get
   - update
   - patch
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  verbs:
+  - get

--- a/pkg/controller/iampolicy/iampolicy_group_polyfill_test.go
+++ b/pkg/controller/iampolicy/iampolicy_group_polyfill_test.go
@@ -1,0 +1,46 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package iampolicy
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Define the OpenShift Group kind for tests in order to not add a dependency
+// on OpenShift libraries
+var groupGV = schema.GroupVersion{Group: "user.openshift.io", Version: "v1"}
+
+type group struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Users             []string `json:"users" protobuf:"bytes,2,rep,name=users"`
+}
+
+func (in *group) DeepCopy() *group {
+	if in == nil {
+		return nil
+	}
+	out := new(group)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *group) DeepCopyInto(out *group) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Users != nil {
+		in, out := &in.Users, &out.Users
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+}
+
+func (in *group) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}


### PR DESCRIPTION
When examining which users have a role, group membership must also be
considered. Group membership can only be determined if the group is an
OpenShift Group kind. Otherwise, it is up to the external authentication
system configured with the Kubernetes cluster to provide this value when
the user logs in. In the latter case, there isn't much that can be done.

Resolves https://github.com/open-cluster-management/backlog/issues/14166