### PR TITLE
Fix where the userCount is in the message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV OPERATOR=/usr/local/bin/${COMPONENT} \
     USER_UID=1001 \
     USER_NAME=${COMPONENT}
 
-# install operator binary
+# install the operator binary
 COPY --from=builder ${REPO_PATH}/build/_output/bin/${COMPONENT} ${OPERATOR}
 
 COPY --from=builder ${REPO_PATH}/build/bin /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 # Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-
 # Git vars
 GITHUB_USER ?=
 GITHUB_TOKEN ?=

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -1,3 +1,4 @@
 # Copyright Contributors to the Open Cluster Management project
 
 -include /opt/build-harness/Makefile.prow
+

--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
 - The `iam-policy-controller` is part of the `open-cluster-management` community. For more information, visit: [open-cluster-management.io](https://open-cluster-management.io).
 - Check the [Security guide](SECURITY.md) if you need to report a security issue.
 
-
-
-
 <!---
 Date: June/11/2021
 -->

--- a/pkg/controller/iampolicy/iampolicy_controller.go
+++ b/pkg/controller/iampolicy/iampolicy_controller.go
@@ -43,8 +43,6 @@ const Finalizer = "finalizer.mcm.ibm.com"
 
 const grcCategory = "system-and-information-integrity"
 
-var clusterName = "managedCluster"
-
 // availablePolicies is a cach all all available polices
 var availablePolicies common.SyncedPolicyMap
 
@@ -80,9 +78,6 @@ func Initialize(kClient *kubernetes.Interface, mgr manager.Manager, clsName, nam
 	KubeClient = kClient
 	PlcChan = make(chan *policiesv1.IamPolicy, 100) //buffering up to 100 policies for update
 
-	if clsName != "" {
-		clusterName = clsName
-	}
 	NamespaceWatched = namespace
 
 	EventOnParent = strings.ToLower(eventParent)

--- a/pkg/controller/iampolicy/iampolicy_controller.go
+++ b/pkg/controller/iampolicy/iampolicy_controller.go
@@ -60,6 +60,7 @@ var NamespaceWatched string
 // EventOnParent specifies if we also want to send events to the parent policy. Available options are yes/no/ifpresent
 var EventOnParent string
 
+// Formats the reason section of generated events
 var formatString string = "policy: %s/%s"
 
 // A way to allow exiting out of the periodic policy check loop


### PR DESCRIPTION
The message was changed, but the code which parses the message later
wasn't updated. Now that location is in a const which should make it
more searchable in the future.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

I'm surprised there isn't a unit test for this, but the problem here did appear in the e2e tests in the framework repo. My PR there to update other failing things is blocked by this.